### PR TITLE
flowMC 0.6.0 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "matplotlib",
     "astropy",
     "sncosmo",
-    "flowMC",
+    "flowMC>=0.6.0",
     "h5py",
     "corner",
     "huggingface_hub>=0.13.0"

--- a/src/fiesta/inference/samplers/flowmc.py
+++ b/src/fiesta/inference/samplers/flowmc.py
@@ -79,10 +79,11 @@ class FlowMCSampler:
                                     )
         
         rng_key, subkey = jax.random.split(rng_key)
+        # flowMC 0.6.0 made Sampler's args keyword-only.
         self.Sampler = Sampler(
-            self.prior.n_dim,
-            n_chains,
-            subkey,
+            n_dim=self.prior.n_dim,
+            n_chains=n_chains,
+            rng_key=subkey,
             resource_strategy_bundles=bundle,
         )
 


### PR DESCRIPTION
This PR makes fiesta flowMC 0.6.0 compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the FlowMC dependency to version 0.6.0 or later to ensure compatibility with the latest sampling framework improvements and maintain stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->