### PR TITLE
pages + pypi on main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name == 'push' && github.repository == 'nuclear-multimessenger-astronomy/fiestaEM' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   deploy:
 
+    if: github.repository == 'nuclear-multimessenger-astronomy/fiestaEM'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Only run pages and pypi workflows on the true main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted documentation deployment to pushes from the designated repository on the main branch or version tags.
  * Restricted package publishing workflow execution to the designated repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->