### PR TITLE
Sampler docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Note, that by default only the cpu version of `jax` is installed. If you want to
 ```
 pip install fiestaEM[gpu]
 ```
-or install `jax[cuda12]` as indicated on the [`jax` webpage](https://docs.jax.dev/en/latest/installation.html#installation) manually.
+or install `jax[cuda13]` as indicated on the [`jax` webpage](https://docs.jax.dev/en/latest/installation.html#installation) manually.
 
 To obtain a set of recommended built-in surrogates (see below), additionally run
 

--- a/docs/user_guide/inference/samplers.rst
+++ b/docs/user_guide/inference/samplers.rst
@@ -1,4 +1,196 @@
 Samplers
 --------
 
-TODO!
+There are currently three different samplers that are directly integrated within fiesta's API.
+Of course, the fiesta priors and likelihood functions could also be used with different samplers, but direct use through the ``Fiesta`` sampling class is only possible with either ``flowMC``, ``blackjax-smc``, or ``numpyro-svi``.
+To decide which sampler to use, use the ``sampler`` argument when initializing the ``Fiesta`` class. By default, this will be ``flowMC``.
+You can also pass additional sampling kwargs to the ``Fiesta`` class, if you do not wanna use their standard settings.
+
+We briefly present the different samplers and their optional arguments here.
+
+
+``flowMC`` (default)
+^^^^^^^^^^^^^^^^^^^^
+
+flowMC is an MCMC sampler that combines local Metropolis-adjusted Langevin algorithm (MALA) steps with a normalizing flow that is trained on the fly for efficient global proposals. 
+This significantly improves sampling efficiency for complicated posterior distributions while still sampling the true posterior distribution.
+Details can be found in the ``flowMC`` `paper <https://arxiv.org/abs/2211.06397>`_ and the ``flowMC`` `documentation <https://gw-jax-team.github.io/flowMC/stable/>`_.
+
+The following keyword arguments can be passed to ``Fiesta(..., sampler="flowMC", **sampling_kwargs)``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 60 15
+
+   * - Argument
+     - Description
+     - Default
+   * - ``n_chains`` 
+     - Number of parallel MCMC chains. 
+     - ``500``
+   * - ``n_local_steps`` 
+     - Number of local MALA steps per sampling loop. 
+     - ``50``
+   * - ``n_global_steps`` 
+     - Number of global normalizing-flow proposals per sampling loop. 
+     - ``200``
+   * - ``n_training_loops``
+     - Number of training sampling loops.
+     - ``20``
+   * - ``n_production_loops``
+     - Number of production sampling loops after training.
+     - ``15``
+   * - ``n_epochs``
+     - Number of epochs used to train the normalizing flow during each training loop.
+     - ``100``
+   * - ``rq_spline_n_layers``
+     - Number of rational quadratic spline coupling layers.
+     - ``4``
+   * - ``rq_spline_hidden_units``
+     - Hidden layer sizes of the neural networks used in the normalizing flow.
+     - ``[64, 64]``
+   * - ``rq_spline_n_bins``
+     - Number of bins in each rational quadratic spline transform.
+     - ``8``
+   * - ``mala_step_size``
+     - Step size used by the local MALA sampler.
+     - ``2e-3``
+   * - ``learning_rate``
+     - Learning rate for normalizing flow training.
+     - ``4e-4``
+   * - ``n_max_examples``
+     - Maximum number of training samples stored for training the flow.
+     - ``10000``
+   * - ``n_NFproposal_batch_size``
+     - Batch size for generating normalizing-flow proposals.
+     - ``10000``
+   * - ``chain_batch_size``
+     - Number of chains processed simultaneously.
+     - ``100``
+   * - ``batch_size``
+     - Mini-batch size used during normalizing flow optimization.
+     - ``10000``
+   * - ``verbose``
+     - Print progress information during sampling.
+     - ``True``
+
+For most applications, the default settings provide good performance. 
+The parameters that are most commonly adjusted are ``n_chains``, ``n_training_loops``, ``n_production_loops``, and ``mala_step_size``.
+
+
+.. code-block:: python
+
+    sampler = Fiesta(
+    ...,
+    sampler="flowMC",
+    n_chains=200,
+    n_training_loops=30,
+    n_production_loops=20,
+    mala_step_size=1e-3,
+    )
+
+After sampling, fiesta returns the production samples as the posterior samples. 
+If ``sampler_extra_output=True`` is passed to the ``sample()`` method, additional diagnostic information from both the training and production phases (chains, log probabilities, acceptance rates, and training losses) are saved in two separate files ``results_training.npz`` and ``results_production.npz`` in the output directory.
+
+
+
+``blackjax-smc``
+^^^^^^^^^^^^^^^^
+
+``blackjax-smc`` implements an adaptive Sequential Monte Carlo (SMC) sampler. 
+Instead of directly sampling the posterior, the algorithm starts by drawing particles from the prior distribution and gradually transforms them into posterior samples through a sequence of intermediate distributions by increasing the inverse temperature on the likelihood function.
+At each tempering stage, particles are rejuvenated using an MCMC kernel and resampled when necessary. 
+An advantage of SMC methods is that they naturally provide an estimate of the Bayesian evidence.
+
+The implementation in ``fiesta`` is based on the ``adaptive_tempered_smc`` algorithm from blackjax with automatic tuning of the tempering schedule. 
+More details can be found in the ``blackjax`` `documentation <https://blackjax.readthedocs.io/>`_.
+
+The following keyword arguments can be passed to ``Fiesta(..., sampler="blackjax-smc", **sampling_kwargs)``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 60 20
+
+   * - Argument
+     - Description
+     - Default
+   * - ``n_particles``
+     - Number of particles used by the SMC sampler.
+     - ``8000``
+   * - ``target_ess``
+     - Target relative effective sample size (ESS) used to adapt the tempering schedule. Larger values result in more tempering stages.
+     - ``0.9``
+   * - ``num_mcmc_steps``
+     - Number of MCMC rejuvenation steps performed after each tempering stage.
+     - ``10``
+   * - ``kernel``
+     - MCMC kernel used to rejuvenate particles. Currently only "random_walk" is implemented.
+     - ``random_walk``
+   * - ``random_walk_sigma``
+     - Proposal scale of the random-walk kernel. Ignored for other kernels.
+     - ``0.05``
+
+For most applications, the default settings work well. The parameters that are most commonly adjusted are ``n_particles``, ``target_ess``, ``num_mcmc_steps``, and ``random_walk_sigma``.
+
+.. code-block:: python
+
+    sampler = Fiesta(
+    ...,
+    sampler="blackjax-smc",
+    n_particles=10000,
+    target_ess=0.95,
+    num_mcmc_steps=20,
+    random_walk_sigma=0.03,
+    )
+
+After sampling, ``fiesta`` returns the posterior samples. 
+In addition, the estimated log-evidence is printed to the console. 
+If ``sampler_extra_output=True`` is passed to the ``sample()`` method, ``fiesta`` also saves a ``smc_metadata.json`` file containing diagnostic information.
+
+
+``numpyro-svi``
+^^^^^^^^^^^^^^^
+
+``numpyro-svi`` performs Stochastic Variational Inference (SVI) using ``numpyro``. 
+Instead of drawing exact samples from the posterior, SVI optimizes the parameters of a variational distribution to approximate the posterior by maximizing the Evidence Lower Bound (ELBO). 
+Once optimization has converged, samples are drawn from the optimized variational distribution.
+Here, we use a diagonal truncated normal distribution as variational distribution, meaning this method cannot represent correlations between different parameters. 
+
+Summarized: This SVI method just serves as a cheap approximation method and should not be used to obtain accurate posterior samples.
+
+The following keyword arguments can be passed to ``Fiesta(..., sampler="numpyro-svi", **sampling_kwargs)``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 60 20
+
+   * - Argument
+     - Description
+     - Default
+   * - ``num_iter``
+     - Number of optimization iterations used to fit the variational posterior.
+     - ``10000``
+   * - ``step_size``
+     - Learning rate of the Adam optimizer.
+     - ``0.001``
+   * - ``num_samples``
+     - Number of posterior samples drawn from the optimized variational distribution.
+     - ``1000``
+
+For most applications, the default settings provide a good starting point. 
+If the optimization has not converged, increasing ``num_iter`` is usually the first parameter to adjust. 
+The ``step_size`` may also need tuning if the ELBO is unstable or converges slowly.
+
+.. code-block:: python
+
+    sampler = Fiesta(
+    ...,
+    sampler="numpyro-svi",
+    num_iter=20000,
+    step_size=5e-4,
+    num_samples=5000,
+    )
+
+After optimization, ``fiesta`` draws ``num_samples`` samples from the learned variational distribution and returns them as posterior samples. 
+The final ELBO is printed to the console. 
+If ``sampler_extra_output=True`` is passed to the ``sample()`` method, ``fiesta`` also saves a svi_metadata.json file containing diagnostic information.

--- a/docs/user_guide/inference/samplers.rst
+++ b/docs/user_guide/inference/samplers.rst
@@ -2,21 +2,21 @@ Samplers
 --------
 
 There are currently three different samplers that are directly integrated within fiesta's API.
-Of course, the fiesta priors and likelihood functions could also be used with different samplers, but direct use through the ``Fiesta`` sampling class is only possible with either ``flowMC``, ``blackjax-smc``, or ``numpyro-svi``.
-To decide which sampler to use, use the ``sampler`` argument when initializing the ``Fiesta`` class. By default, this will be ``flowMC``.
+Of course, the fiesta priors and likelihood functions could also be used with different samplers, but direct use through the ``Fiesta`` sampling class is only possible with either ``flowmc``, ``blackjax-smc``, or ``numpyro-svi``.
+To decide which sampler to use, use the ``sampler`` argument when initializing the ``Fiesta`` class. By default, this will be ``flowmc``.
 You can also pass additional sampling kwargs to the ``Fiesta`` class, if you do not wanna use their standard settings.
 
 We briefly present the different samplers and their optional arguments here.
 
 
-``flowMC`` (default)
+``flowmc`` (default)
 ^^^^^^^^^^^^^^^^^^^^
 
 flowMC is an MCMC sampler that combines local Metropolis-adjusted Langevin algorithm (MALA) steps with a normalizing flow that is trained on the fly for efficient global proposals. 
 This significantly improves sampling efficiency for complicated posterior distributions while still sampling the true posterior distribution.
-Details can be found in the ``flowMC`` `paper <https://arxiv.org/abs/2211.06397>`_ and the ``flowMC`` `documentation <https://gw-jax-team.github.io/flowMC/stable/>`_.
+Details can be found in the flowMC `paper <https://arxiv.org/abs/2211.06397>`_ and the `documentation <https://gw-jax-team.github.io/flowMC/stable/>`_.
 
-The following keyword arguments can be passed to ``Fiesta(..., sampler="flowMC", **sampling_kwargs)``:
+The following keyword arguments can be passed to ``Fiesta(..., sampler="flowmc", **sampling_kwargs)``:
 
 .. list-table::
    :header-rows: 1
@@ -82,7 +82,7 @@ The parameters that are most commonly adjusted are ``n_chains``, ``n_training_lo
 
     sampler = Fiesta(
     ...,
-    sampler="flowMC",
+    sampler="flowmc",
     n_chains=200,
     n_training_loops=30,
     n_production_loops=20,
@@ -90,7 +90,7 @@ The parameters that are most commonly adjusted are ``n_chains``, ``n_training_lo
     )
 
 After sampling, fiesta returns the production samples as the posterior samples. 
-If ``sampler_extra_output=True`` is passed to the ``sample()`` method, additional diagnostic information from both the training and production phases (chains, log probabilities, acceptance rates, and training losses) are saved in two separate files ``results_training.npz`` and ``results_production.npz`` in the output directory.
+If ``sampler_extra_output=True`` is passed to the ``Fiesta.save_results()`` method, additional diagnostic information from both the training and production phases (chains, log probabilities, acceptance rates, and training losses) are saved in two separate files ``results_training.npz`` and ``results_production.npz`` in the output directory.
 
 
 
@@ -145,7 +145,7 @@ For most applications, the default settings work well. The parameters that are m
 
 After sampling, ``fiesta`` returns the posterior samples. 
 In addition, the estimated log-evidence is printed to the console. 
-If ``sampler_extra_output=True`` is passed to the ``sample()`` method, ``fiesta`` also saves a ``smc_metadata.json`` file containing diagnostic information.
+If ``sampler_extra_output=True`` is passed to the ``Fiesta.save_results()`` method, ``fiesta`` also saves a ``smc_metadata.json`` file containing diagnostic information.
 
 
 ``numpyro-svi``
@@ -193,4 +193,4 @@ The ``step_size`` may also need tuning if the ELBO is unstable or converges slow
 
 After optimization, ``fiesta`` draws ``num_samples`` samples from the learned variational distribution and returns them as posterior samples. 
 The final ELBO is printed to the console. 
-If ``sampler_extra_output=True`` is passed to the ``sample()`` method, ``fiesta`` also saves a svi_metadata.json file containing diagnostic information.
+If ``sampler_extra_output=True`` is passed to the ``Fiesta.save_results()`` method, ``fiesta`` also saves a svi_metadata.json file containing diagnostic information.

--- a/examples/inference/.gitignore
+++ b/examples/inference/.gitignore
@@ -1,1 +1,2 @@
 submit.sh
+outdir*

--- a/examples/inference/inference_KN.py
+++ b/examples/inference/inference_KN.py
@@ -1,10 +1,11 @@
 import numpy as np
 import jax
+import jax.numpy as jnp
 
 from fiesta.inference.prior import Uniform, ConstrainedPrior, Sine
 from fiesta.inference.fiesta import Fiesta
 from fiesta.inference.likelihood import EMLikelihood
-from fiesta.inference.lightcurve_model import BullaFlux
+from fiesta.inference.lightcurve_model import FluxModel
 from fiesta.utils import load_event_data
 
 
@@ -24,8 +25,10 @@ FILTERS = list(data.keys())
 # MODEL #
 #########
 
-model = BullaFlux(name="Bu2026_MLP",
-                  filters = FILTERS)
+model = FluxModel(
+    name="Bu2026_MLP",
+    filters = FILTERS
+)
 
 
 #########
@@ -33,8 +36,8 @@ model = BullaFlux(name="Bu2026_MLP",
 #########
 
 KN_prior = [
-            Sine(xmin=0., xmax=np.pi/2, naming=["inclination_EM"]),
-            Uniform(xmin=-4.0, xmax=-1.3, naming=["log10_mej_dyn"]),
+            Sine(xmin=0., xmax=jnp.pi/2, naming=["inclination_EM"]),
+            Uniform(xmin=-3.0, xmax=-1.3, naming=["log10_mej_dyn"]),
             Uniform(xmin=0.12, xmax=0.35, naming=["v_ej_dyn"]),
             Uniform(xmin=0.15, xmax=0.35, naming=["Ye_dyn"]),
             Uniform(xmin=-4., xmax=-0.56, naming=["log10_mej_wind"]),
@@ -56,7 +59,7 @@ detection_limit = None
 likelihood = EMLikelihood(model,
                           data,
                           data_tmin=0.3,
-                          data_tmax=28.,
+                          data_tmax=10.,
                           trigger_time=trigger_time,
                           detection_limit = detection_limit,
                           fixed_params={"luminosity_distance": 43.583656, "redshift":0.009727})
@@ -64,10 +67,12 @@ likelihood = EMLikelihood(model,
 
 outdir = f"./outdir_KN/"
 
-fiesta = Fiesta(likelihood,
-                prior,
-                systematics_file="./systematics_file_KN.yaml",
-                outdir = outdir)
+fiesta = Fiesta(
+    likelihood,
+    prior,
+    systematics_file="./systematics_file_KN.yaml",
+    outdir = outdir
+)
 
 
 if __name__ == "__main__":

--- a/examples/inference/systematics_file_KN.yaml
+++ b/examples/inference/systematics_file_KN.yaml
@@ -1,6 +1,6 @@
 collective:
     time_nodes: 4
-    time_range: linear 0.3 10
+    time_range: linear 0.3 8
     prior: Uniform
     params:
         xmin: 0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ samplers = ["fiestaEM[flowmc,blackjax,numpyro]"]
 grb = ["afterglowpy"]
 # cuda12 (not 13): the CUDA 12 wheels run on driver >=525, matching far more
 # OSPool GPU nodes than cuda13's >=580 floor.
-gpu = ["jax[cuda12]"]
+gpu = ["jax[cuda13]"]
 docs = [
     "sphinx>=7.0",
     "sphinx-autobuild",

--- a/src/fiesta/scalers.py
+++ b/src/fiesta/scalers.py
@@ -40,8 +40,8 @@ class MinMaxScalerJax(Scaler):
     """
     
     def __init__(self,
-                 min_val: Array = 1.,
-                 max_val: Array = 0.):
+                 min_val: Array = 0.,
+                 max_val: Array = 1.):
         
         self.min_val = min_val
         self.max_val = max_val


### PR DESCRIPTION
In this PR

i) set cuda13 again in pyproject.toml
ii) add documentation for the three different sampler we can use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide to the supported inference samplers, including configuration options, setup examples, and diagnostic output.
* **Bug Fixes**
  * Corrected default scaling bounds to use the standard 0–1 range.
* **Examples**
  * Updated kilonova inference examples with refined model settings, prior bounds, time ranges, and output-directory handling.
* **Compatibility**
  * Updated GPU configuration for newer CUDA environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->